### PR TITLE
Fix range error

### DIFF
--- a/rawhdr/common.py
+++ b/rawhdr/common.py
@@ -27,7 +27,7 @@ def load_image(path, return_original_dtype=False):
                                   no_auto_bright=True,
                                   use_camera_wb=True,
                                   output_bps=16)
-        rgb = rgb.astype('float32') / np.float32(2**16)
+        rgb = rgb.astype('float32') / np.float32(2**16 - 1)
         dtype = rgb.dtype
     except rawpy._rawpy.LibRawError:
         rgb = imageio.imread(path)


### PR DESCRIPTION
Conversion currently produces output [0, 1), but range should be inclusive [0, 1]